### PR TITLE
allow includes in jade.compile by including the filename option

### DIFF
--- a/lib/jade-amd.js
+++ b/lib/jade-amd.js
@@ -59,7 +59,7 @@ exports.jadeAmdMiddleware = function (options) {
         exports.toAmdString(
           jade.compile(
             template,
-            {client: true, compileDebug: false }
+            {client: true, compileDebug: false, filename : template_abs_path }
           )
         )
       );


### PR DESCRIPTION
I was having issues with templates with includes in them (middleware). This seemed to have fixed the issue. I am not sure if there was a solution for this. If so please let me know

Thanks.
