### PR TITLE
hold version of findit

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "commander": ">= 0.6.0",
     "mkdirp": ">= 0.3.2",
-    "findit": ">= 0.1.2"
+    "findit": "0.1.2"
   },
   "devDependencies": {
     "express": ">=2 <3",


### PR DESCRIPTION
holding version of `findit` prevents error `has no method 'find'` at bin/jade-amd:52 with findit 1.1 (maybe and in earlier versions)
