### PR TITLE
Added (jade = ) to be compatible with new jade version

### DIFF
--- a/lib/jade-amd.js
+++ b/lib/jade-amd.js
@@ -34,7 +34,7 @@ var jadeRuntimeSource = fs.readFileSync(jadeRuntimePath);
 
 exports.jadeRuntimeAmdString = "define([], function() {\n"
   // 0.25.0 has no 'var' at start, 0.26.0 does
-  + ( /^\s*var /.test(jadeRuntimeSource) ? '' : 'var ' )
+  + ( /^\s*var /.test(jadeRuntimeSource) ? '' : 'var jade = ' )
   + jadeRuntimeSource
   + "\nreturn jade;\n});\n";
 


### PR DESCRIPTION
Added `jade =` to be compatible with new version of Jade
runtime.js does not include this since this commit https://github.com/visionmedia/jade/commit/72043cd7ed1d7dbed6dcd9ca315c9f1f41ef38b3#diff-180a4c8e5bf3b0c453ab1a7e06c9e0ceL2
