### PR TITLE
Update to use compileClient

### DIFF
--- a/lib/jade-amd.js
+++ b/lib/jade-amd.js
@@ -63,9 +63,9 @@ exports.jadeAmdMiddleware = function (options) {
 
       res.end(
         exports.toAmdString(
-          jade.compile(
+          jade.compileClient(
             template,
-            { client: true, compileDebug: false, filename : template_abs_path }
+            { compileDebug: false, filename : template_abs_path }
           )
         )
       );


### PR DESCRIPTION
The `client` option is deprecated in favour of using the method `compileClient()`.
