### PR TITLE
Fixes deprecation of client option

### DIFF
--- a/bin/jade-amd
+++ b/bin/jade-amd
@@ -33,7 +33,6 @@ if (program.runtime) {
 
 // jade options
 var options = {
-  client: true,
   compileDebug: false,
   pretty: program.pretty,
   jadeRuntime: program.jadeRuntime
@@ -70,7 +69,7 @@ function renderFile(fromPath, toPath) {
     }
 
     options.filename = fromPath;
-    var fn = jade.compile(str, options);
+    var fn = jade.compileClient(str, options);
     var dir = path.resolve(path.dirname(toPath));
 
     mkdirp(dir, 0755, function (err) {


### PR DESCRIPTION
Fixes the following warning during compilation: 

Warning: The `client` option is deprecated, use the `jade.compileClient` method instead
    at Function.res.toString (C:\Users\...\AppData\Roaming\npm\node_modules\jade\lib\index.js:222:17)
    at Object.exports.toAmdString (C:\Users\...\AppData\Roaming\npm\node_modules\jade-amd\lib\jade-amd.js:28:84)
    at C:\Users\...\AppData\Roaming\npm\node_modules\jade-amd\bin\jade-amd:81:31
    at C:\Users\...\AppData\Roaming\npm\node_modules\jade-amd\node_modules\mkdirp\index.js:47:26
    at FSReqWrap.oncomplete (fs.js:99:15)
