### PR TITLE
Issue #16:

### DIFF
--- a/bin/jade-amd
+++ b/bin/jade-amd
@@ -54,7 +54,7 @@ finder.on('file', function (file) {
   var suffixRe = /\.jade$/;
 
   if (suffixRe.test(file)) {
-    var local_path = file.replace(new RegExp('^' + program.from + '/?'), '');
+    var local_path = path.relative(program.from, file);
     var fromPath = path.join(program.from, local_path);
     var toPath = path.join(program.to, local_path).replace(suffixRe, '.js');
 


### PR DESCRIPTION
Fix issue with slashes in windows paths.

If for some reason this fix is not acceptable (compatibility with older version of node, etc) the windows slashes can be escaped in the `program.from` path. I tested that solution as well. let me know if you want to do something different.

Thanks.