### PR TITLE
mkdirp@1 breaks jade-amd

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "commander": ">= 0.6.0",
-    "mkdirp": ">= 0.3.2",
+    "mkdirp": "^0.3.2",
     "findit": ">= 0.1.2",
     "semver": "~2.2.1"
   },


### PR DESCRIPTION
`mkdirp` dropped callbacks support since `1.x`, so only `mkdirp@0.x` versions are compatible with `jade-amd`